### PR TITLE
Close ATA script for token cleanup (learning example)

### DIFF
--- a/learning-examples/cleanup_accounts.py
+++ b/learning-examples/cleanup_accounts.py
@@ -1,0 +1,87 @@
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from solders.pubkey import Pubkey
+from spl.token.instructions import BurnParams, CloseAccountParams, burn, close_account
+
+from core.client import SolanaClient
+from core.pubkeys import SystemAddresses
+from core.wallet import Wallet
+from utils.logger import get_logger
+
+load_dotenv()
+logger = get_logger(__name__)
+
+RPC_ENDPOINT = os.getenv("SOLANA_NODE_RPC_ENDPOINT")
+PRIVATE_KEY = os.getenv("SOLANA_PRIVATE_KEY")
+
+# Update this address to MINT address of a token you want to close
+MINT_ADDRESS = Pubkey.from_string("9WHpYbqG6LJvfCYfMjvGbyo1wHXgroCrixPb33s2pump")
+
+
+async def close_account_if_exists(client: SolanaClient, wallet: Wallet, account: Pubkey, mint: Pubkey):
+    """Safely close a token account if it exists and reclaim rent."""
+    try:
+        solana_client = await client.get_client()
+        info = await solana_client.get_account_info(account)
+
+        # WARNING: This will permanently burn all tokens in the account before closing it
+        # Closing account is impossible if balance is positive
+        balance = await client.get_token_account_balance(account)
+        if balance > 0:
+            logger.info(f"Burning {balance} tokens from account {account}...")
+            burn_ix = burn(
+                BurnParams(
+                    account=account,
+                    mint=mint,
+                    owner=wallet.pubkey,
+                    amount=balance,
+                    program_id=SystemAddresses.TOKEN_PROGRAM,
+                )
+            )
+            await client.build_and_send_transaction([burn_ix], wallet.keypair)
+            logger.info(f"Burned tokens from {account}")
+
+        # If account exists, attempt to close it
+        if info.value:
+            logger.info(f"Closing account: {account}")
+            close_params = CloseAccountParams(
+                account=account,
+                dest=wallet.pubkey,
+                owner=wallet.pubkey,
+                program_id=SystemAddresses.TOKEN_PROGRAM,
+            )
+            ix = close_account(close_params)
+
+            tx_sig = await client.build_and_send_transaction(
+                [ix],
+                wallet.keypair,
+                skip_preflight=True,
+            )
+            await client.confirm_transaction(tx_sig)
+            logger.info(f"Closed successfully: {account}")
+        else:
+            logger.info(f"Account does not exist or already closed: {account}")
+
+    except Exception as e:
+        logger.error(f"Error while processing account {account}: {e}")
+
+
+async def main():
+    try:
+        client = SolanaClient(RPC_ENDPOINT)
+        wallet = Wallet(PRIVATE_KEY)
+
+        # Get user's ATA for the token
+        ata = wallet.get_associated_token_address(MINT_ADDRESS)
+        await close_account_if_exists(client, wallet, ata, MINT_ADDRESS)
+
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}")
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
This PR adds a standalone script in `learning-examples/` to safely burn tokens and close the user's Associated Token Account (ATA), reclaiming the SOL used as rent.

✅ Why this matters:
After trading tokens, ATA accounts remain open, holding tokens with no value. Each open ATA locks ~0.002 SOL in rent — over time, this adds up. This script helps recover that SOL in a safe and user-friendly way.

🔒 Safety:

1. Checks token balance before closing.
2. If non-zero, burns all tokens (irreversible).
3. Then closes the account and confirms the transaction.

⚠️ What about ABCA (Associated Bonding Curve Account)?

1. It is not owned by the user.
2. It does not reserve SOL from the wallet.
3. The ABCA was included in the original feature request but is out of scope for user cleanup.

This script will be integrated into the main trading bot flow in a future update.

Related issues: https://github.com/chainstacklabs/pump-fun-bot/issues/31