### PR TITLE
Integrate ATA closing into trader

### DIFF
--- a/src/cleanup/manager.py
+++ b/src/cleanup/manager.py
@@ -1,0 +1,83 @@
+from solders.pubkey import Pubkey
+from spl.token.instructions import BurnParams, CloseAccountParams, burn, close_account
+
+from config import CLEANUP_WITHOUT_PRIORITY_FEE
+from core.client import SolanaClient
+from core.pubkeys import SystemAddresses
+from core.wallet import Wallet
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class AccountCleanupManager:
+    """Handles safe cleanup of token accounts (ATA) after trading sessions."""
+
+    def __init__(
+        self,
+        client: SolanaClient,
+        wallet: Wallet,
+    ):
+        """
+        Args:
+            client: Solana RPC client
+            wallet: Wallet for signing transactions
+        """
+        self.client = client
+        self.wallet = wallet
+        self.use_priority_fee = not CLEANUP_WITHOUT_PRIORITY_FEE
+
+    async def cleanup_ata(self, mint: Pubkey) -> None:
+        """
+        Attempt to burn any remaining tokens and close the ATA.
+        Skips if account doesn't exist or is already empty/closed.
+        """
+        ata = self.wallet.get_associated_token_address(mint)
+        solana_client = await self.client.get_client()
+
+        try:
+            info = await solana_client.get_account_info(ata)
+            if not info.value:
+                logger.info(f"ATA {ata} does not exist or already closed.")
+                return
+
+            balance = await self.client.get_token_account_balance(ata)
+            if balance > 0:
+                logger.info(f"⚠️ Burning {balance} tokens from ATA {ata} (mint: {mint})...")
+                burn_ix = burn(
+                    BurnParams(
+                        account=ata,
+                        mint=mint,
+                        owner=self.wallet.pubkey,
+                        amount=balance,
+                        program_id=SystemAddresses.TOKEN_PROGRAM,
+                    )
+                )
+                await self.client.build_and_send_transaction(
+                    [burn_ix],
+                    self.wallet.keypair,
+                    skip_preflight=True,
+                    priority_fee=None if not self.use_priority_fee else 0,
+                )
+                logger.info(f"✅ Burned successfully from ATA {ata}")
+
+            logger.info(f"Closing ATA: {ata}")
+            close_ix = close_account(
+                CloseAccountParams(
+                    account=ata,
+                    dest=self.wallet.pubkey,
+                    owner=self.wallet.pubkey,
+                    program_id=SystemAddresses.TOKEN_PROGRAM,
+                )
+            )
+            tx_sig = await self.client.build_and_send_transaction(
+                [close_ix],
+                self.wallet.keypair,
+                skip_preflight=True,
+                priority_fee=None if not self.use_priority_fee else 0,
+            )
+            await self.client.confirm_transaction(tx_sig)
+            logger.info(f"✅ Closed successfully: {ata}")
+
+        except Exception as e:
+            logger.warning(f"⚠️ Cleanup failed for ATA {ata}: {e!s}")

--- a/src/cleanup/manager.py
+++ b/src/cleanup/manager.py
@@ -1,8 +1,9 @@
 from solders.pubkey import Pubkey
 from spl.token.instructions import BurnParams, CloseAccountParams, burn, close_account
 
-from config import CLEANUP_WITHOUT_PRIORITY_FEE
+from config import CLEANUP_FORCE_CLOSE_WITH_BURN
 from core.client import SolanaClient
+from core.priority_fee.manager import PriorityFeeManager
 from core.pubkeys import SystemAddresses
 from core.wallet import Wallet
 from utils.logger import get_logger
@@ -12,11 +13,12 @@ logger = get_logger(__name__)
 
 class AccountCleanupManager:
     """Handles safe cleanup of token accounts (ATA) after trading sessions."""
-
     def __init__(
         self,
         client: SolanaClient,
         wallet: Wallet,
+        priority_fee_manager: PriorityFeeManager,
+        use_priority_fee: bool = False,
     ):
         """
         Args:
@@ -25,7 +27,8 @@ class AccountCleanupManager:
         """
         self.client = client
         self.wallet = wallet
-        self.use_priority_fee = not CLEANUP_WITHOUT_PRIORITY_FEE
+        self.priority_fee_manager = priority_fee_manager
+        self.use_priority_fee = use_priority_fee
 
     async def cleanup_ata(self, mint: Pubkey) -> None:
         """
@@ -35,6 +38,12 @@ class AccountCleanupManager:
         ata = self.wallet.get_associated_token_address(mint)
         solana_client = await self.client.get_client()
 
+        priority_fee = (
+            await self.priority_fee_manager.calculate_priority_fee([ata])
+            if self.use_priority_fee
+            else None
+        )
+
         try:
             info = await solana_client.get_account_info(ata)
             if not info.value:
@@ -42,8 +51,8 @@ class AccountCleanupManager:
                 return
 
             balance = await self.client.get_token_account_balance(ata)
-            if balance > 0:
-                logger.info(f"⚠️ Burning {balance} tokens from ATA {ata} (mint: {mint})...")
+            if balance > 0 and CLEANUP_FORCE_CLOSE_WITH_BURN:
+                logger.info(f"Burning {balance} tokens from ATA {ata} (mint: {mint})...")
                 burn_ix = burn(
                     BurnParams(
                         account=ata,
@@ -57,9 +66,15 @@ class AccountCleanupManager:
                     [burn_ix],
                     self.wallet.keypair,
                     skip_preflight=True,
-                    priority_fee=None if not self.use_priority_fee else 0,
+                    priority_fee=priority_fee,
                 )
                 logger.info(f"✅ Burned successfully from ATA {ata}")
+            elif balance > 0:
+                logger.info(
+                    f"Skipping ATA {ata} with non-zero balance ({balance} tokens) "
+                    f"because CLEANUP_FORCE_CLOSE_WITH_BURN is disabled."
+                )
+                return
 
             logger.info(f"Closing ATA: {ata}")
             close_ix = close_account(
@@ -74,10 +89,10 @@ class AccountCleanupManager:
                 [close_ix],
                 self.wallet.keypair,
                 skip_preflight=True,
-                priority_fee=None if not self.use_priority_fee else 0,
+                priority_fee=priority_fee,
             )
             await self.client.confirm_transaction(tx_sig)
-            logger.info(f"✅ Closed successfully: {ata}")
+            logger.info(f"Closed successfully: {ata}")
 
         except Exception as e:
-            logger.warning(f"⚠️ Cleanup failed for ATA {ata}: {e!s}")
+            logger.warning(f"Cleanup failed for ATA {ata}: {e!s}")

--- a/src/cleanup/modes.py
+++ b/src/cleanup/modes.py
@@ -1,0 +1,39 @@
+from cleanup.manager import AccountCleanupManager
+from config import CLEANUP_MODE, CLEANUP_WITHOUT_PRIORITY_FEE
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def should_cleanup_after_failure() -> bool:
+    return CLEANUP_MODE == "on_fail"
+
+
+def should_cleanup_after_sell() -> bool:
+    return CLEANUP_MODE == "after_sell"
+
+
+def should_cleanup_post_session() -> bool:
+    return CLEANUP_MODE == "post_session"
+
+
+async def handle_cleanup_after_failure(client, wallet, mint):
+    if should_cleanup_after_failure():
+        logger.info("[Cleanup] Triggered by failed buy transaction.")
+        manager = AccountCleanupManager(client, wallet, use_priority_fee=not CLEANUP_WITHOUT_PRIORITY_FEE)
+        await manager.cleanup_ata(mint)
+
+
+async def handle_cleanup_after_sell(client, wallet, mint):
+    if should_cleanup_after_sell():
+        logger.info("[Cleanup] Triggered after token sell.")
+        manager = AccountCleanupManager(client, wallet, use_priority_fee=not CLEANUP_WITHOUT_PRIORITY_FEE)
+        await manager.cleanup_ata(mint)
+
+
+async def handle_cleanup_post_session(client, wallet, mints):
+    if should_cleanup_post_session():
+        logger.info("[Cleanup] Triggered post trading session.")
+        manager = AccountCleanupManager(client, wallet, use_priority_fee=not CLEANUP_WITHOUT_PRIORITY_FEE)
+        for mint in mints:
+            await manager.cleanup_ata(mint)

--- a/src/cleanup/modes.py
+++ b/src/cleanup/modes.py
@@ -1,5 +1,5 @@
 from cleanup.manager import AccountCleanupManager
-from config import CLEANUP_MODE, CLEANUP_WITHOUT_PRIORITY_FEE
+from config import CLEANUP_MODE, CLEANUP_WITH_PRIORITY_FEE
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -17,23 +17,21 @@ def should_cleanup_post_session() -> bool:
     return CLEANUP_MODE == "post_session"
 
 
-async def handle_cleanup_after_failure(client, wallet, mint):
+async def handle_cleanup_after_failure(client, wallet, mint, priority_fee_manager):
     if should_cleanup_after_failure():
         logger.info("[Cleanup] Triggered by failed buy transaction.")
-        manager = AccountCleanupManager(client, wallet, use_priority_fee=not CLEANUP_WITHOUT_PRIORITY_FEE)
+        manager = AccountCleanupManager(client, wallet, priority_fee_manager, CLEANUP_WITH_PRIORITY_FEE)
         await manager.cleanup_ata(mint)
 
-
-async def handle_cleanup_after_sell(client, wallet, mint):
+async def handle_cleanup_after_sell(client, wallet, mint, priority_fee_manager):
     if should_cleanup_after_sell():
         logger.info("[Cleanup] Triggered after token sell.")
-        manager = AccountCleanupManager(client, wallet, use_priority_fee=not CLEANUP_WITHOUT_PRIORITY_FEE)
+        manager = AccountCleanupManager(client, wallet, priority_fee_manager, CLEANUP_WITH_PRIORITY_FEE)
         await manager.cleanup_ata(mint)
 
-
-async def handle_cleanup_post_session(client, wallet, mints):
+async def handle_cleanup_post_session(client, wallet, mints, priority_fee_manager):
     if should_cleanup_post_session():
         logger.info("[Cleanup] Triggered post trading session.")
-        manager = AccountCleanupManager(client, wallet, use_priority_fee=not CLEANUP_WITHOUT_PRIORITY_FEE)
+        manager = AccountCleanupManager(client, wallet, priority_fee_manager, CLEANUP_WITH_PRIORITY_FEE)
         for mint in mints:
             await manager.cleanup_ata(mint)

--- a/src/cli.py
+++ b/src/cli.py
@@ -8,7 +8,7 @@ import asyncio
 import os
 import sys
 
-import config as config
+import config
 from trading.trader import PumpTrader
 from utils.logger import get_logger, setup_file_logging
 
@@ -109,7 +109,7 @@ async def main() -> None:
     except KeyboardInterrupt:
         logger.info("Trading stopped by user")
     except Exception as e:
-        logger.error(f"Trading stopped due to error: {str(e)}")
+        logger.error(f"Trading stopped due to error: {e!s}")
     finally:
         try:
             await trader.solana_client.close()
@@ -117,7 +117,7 @@ async def main() -> None:
             pass
 
 
-def sync_main():
+def sync_main() -> None:
     asyncio.run(main())
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,7 @@ Carefully review and adjust values to match your trading strategy and risk toler
 
 # Trading parameters
 # Control trade execution: amount of SOL per trade and acceptable price deviation
-BUY_AMOUNT: int | float = 0.000_001  # Minimal SOL amount to prevent dust transactions
+BUY_AMOUNT: int | float = 0.000_001  # Amount of SOL to spend when buying
 BUY_SLIPPAGE: float = 0.4  # Maximum acceptable price deviation (0.4 = 40%)
 SELL_SLIPPAGE: float = 0.4  # Consistent slippage tolerance to maintain trading strategy
 
@@ -17,7 +17,7 @@ SELL_SLIPPAGE: float = 0.4  # Consistent slippage tolerance to maintain trading 
 ENABLE_DYNAMIC_PRIORITY_FEE: bool = False  # Adaptive fee calculation
 ENABLE_FIXED_PRIORITY_FEE: bool = True  # Use consistent, predictable fee
 FIXED_PRIORITY_FEE: int = 2_000  # Base fee in microlamports
-EXTRA_PRIORITY_FEE: float = 0.0  # Percentage increase on base priority fee (0.1 = 10%)
+EXTRA_PRIORITY_FEE: float = 0.0  # Percentage increase on priority fee (0.1 = 10%)
 HARD_CAP_PRIOR_FEE: int = 200_000  # Maximum allowable fee to prevent excessive spending in microlamports
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -48,6 +48,21 @@ WAIT_TIME_BEFORE_NEW_TOKEN: int | float = (
 MAX_TOKEN_AGE: int | float = 0.1
 
 
+# Cleanup configuration
+
+# CLEANUP_MODE controls when to attempt closing token accounts (ATA)
+# Options:
+#   - "disabled": no cleanup at all
+#   - "on_fail": close ATA only if a buy transaction fails
+#   - "after_sell": close ATA after selling, but only if token balance is zero
+#   - "post_session": clean up all empty ATA accounts at the end of trading session
+CLEANUP_MODE: str = "disabled"
+
+# If True, cleanup transactions will skip priority fees (cheaper, slower confirmation)
+# Set to False if you want faster confirmations (e.g. when racing for SOL reclaim)
+CLEANUP_WITHOUT_PRIORITY_FEE: bool = True
+
+
 # Node provider configuration
 # Tested with Chainstack nodes (https://console.chainstack.com), but you can use any node provider
 # You can get a trader node https://docs.chainstack.com/docs/solana-trader-nodes

--- a/src/config.py
+++ b/src/config.py
@@ -47,8 +47,8 @@ MAX_TOKEN_AGE: int | float = 0.1  # Maximum token age in seconds for processing
 # "on_fail": Only clean up if a buy transaction fails.
 # "after_sell": Clean up after selling, but only if the balance is zero.
 # "post_session": Clean up all empty accounts after a trading session ends.
-CLEANUP_MODE: str = "after_sell"
-CLEANUP_FORCE_CLOSE_WITH_BURN: bool = True  # Burn remaining tokens before closing account, else skip ATA with non-zero balances
+CLEANUP_MODE: str = "disabled"
+CLEANUP_FORCE_CLOSE_WITH_BURN: bool = False  # Burn remaining tokens before closing account, else skip ATA with non-zero balances
 CLEANUP_WITH_PRIORITY_FEE: bool = False  # Use priority fees for cleanup transactions
 
 

--- a/src/trading/trader.py
+++ b/src/trading/trader.py
@@ -8,7 +8,7 @@ import json
 import os
 from datetime import datetime
 
-import config as config
+import config
 from core.client import SolanaClient
 from core.curve import BondingCurveManager
 from core.priority_fee.manager import PriorityFeeManager
@@ -137,7 +137,7 @@ class PumpTrader:
             )
 
         except Exception as e:
-            logger.error(f"Trading stopped due to error: {str(e)}")
+            logger.error(f"Trading stopped due to error: {e!s}")
             processor_task.cancel()
             await self.solana_client.close()
 
@@ -153,7 +153,7 @@ class PumpTrader:
         self.token_timestamps[token_key] = asyncio.get_event_loop().time()
 
         await self.token_queue.put(token_info)
-        # logger.info(f"Queued new token: {token_info.symbol} ({token_info.mint})")
+        logger.info(f"Queued new token: {token_info.symbol} ({token_info.mint})")
 
     async def _process_token_queue(self, marry_mode: bool, yolo_mode: bool) -> None:
         """Continuously process tokens from the queue, only if they're fresh."""
@@ -254,7 +254,7 @@ class PumpTrader:
             await asyncio.sleep(config.WAIT_TIME_BEFORE_NEW_TOKEN)
 
         except Exception as e:
-            logger.error(f"Error handling token {token_info.symbol}: {str(e)}")
+            logger.error(f"Error handling token {token_info.symbol}: {e!s}")
 
     async def _save_token_info(self, token_info: TokenInfo) -> None:
         """Save token information to a file.


### PR DESCRIPTION
This PR introduces ATA closing and token burning functionality into the main trading bot flow, a feature previously available only in the learning examples. Users can now safely reclaim SOL by burning any remaining tokens and closing their Associated Token Accounts (ATAs) after trading. The behavior is fully configurable through a new setting in the bot’s configuration.

✅ Why this matters:

After trading tokens, Associated Token Accounts (ATAs) can remain open, holding tokens that no longer have value. These open ATAs consume SOL for rent (approximately 0.002 SOL per account), which accumulates over time. By enabling ATA closing and token burning, this PR helps users recover the SOL used for rent by ensuring unused ATAs are cleaned up.

🔒 Safety considerations:
1. Token burn: if the config option `CLEANUP_FORCE_CLOSE_WITH_BURN` is enabled, any remaining tokens in the ATA will be burned before the account is closed. This is an irreversible operation.
2. Balance check: if the ATA contains tokens and burning is not enabled, the ATA will be skipped and left open.

🔧 Config section:

In the bot's configuration (`config.py`), users can set cleanup behavior:
```python
# Cleanup mode determines when to manage token accounts. Options:
# "disabled": No cleanup will occur.
# "on_fail": Only clean up if a buy transaction fails.
# "after_sell": Clean up after selling, but only if the balance is zero.
# "post_session": Clean up all empty accounts after a trading session ends.
CLEANUP_MODE: str = "disabled"

# If True, remaining tokens will be burned before closing ATA, else the ATA will be skipped if non-zero balance.
CLEANUP_FORCE_CLOSE_WITH_BURN: bool = False

# If True, priority fees will be applied to cleanup transactions
CLEANUP_WITH_PRIORITY_FEE: bool = False
```