### PR TITLE
Fix Geyser authentication type in tests

### DIFF
--- a/tests/compare_listeners.py
+++ b/tests/compare_listeners.py
@@ -74,6 +74,7 @@ async def run_comparison(test_duration: int = 300):
     wss_endpoint = os.environ.get("SOLANA_NODE_WSS_ENDPOINT")
     geyser_endpoint = os.environ.get("GEYSER_ENDPOINT")
     geyser_api_token = os.environ.get("GEYSER_API_TOKEN")
+    geyser_auth_type = os.environ.get("GEYSER_AUTH_TYPE", "x-token")
     
     if not wss_endpoint:
         logger.error("SOLANA_NODE_WSS_ENDPOINT environment variable is not set")
@@ -98,7 +99,7 @@ async def run_comparison(test_duration: int = 300):
     # Initialize Geyser listener if credentials are available
     if geyser_endpoint and geyser_api_token:
         logger.info(f"Connecting to Geyser API: {geyser_endpoint}")
-        geyser_listener = GeyserListener(geyser_endpoint, geyser_api_token, PumpAddresses.PROGRAM)
+        geyser_listener = GeyserListener(geyser_endpoint, geyser_api_token, geyser_auth_type, PumpAddresses.PROGRAM)
         geyser_callback = TimingTokenCallback("GeyserListener")
         
         listener_tasks.append(

--- a/tests/test_geyser_listener.py
+++ b/tests/test_geyser_listener.py
@@ -53,6 +53,7 @@ async def test_geyser_listener(
     """Test the Geyser listener functionality"""
     geyser_endpoint = os.environ.get("GEYSER_ENDPOINT")
     geyser_api_token = os.environ.get("GEYSER_API_TOKEN")
+    geyser_auth_type = os.environ.get("GEYSER_AUTH_TYPE", "x-token")
     
     if not geyser_endpoint:
         logger.error("GEYSER_ENDPOINT environment variable is not set")
@@ -61,9 +62,9 @@ async def test_geyser_listener(
     if not geyser_api_token:
         logger.error("GEYSER_API_TOKEN environment variable is not set")
         return []
-    
+
     logger.info(f"Connecting to Geyser API: {geyser_endpoint}")
-    listener = GeyserListener(geyser_endpoint, geyser_api_token, PumpAddresses.PROGRAM)
+    listener = GeyserListener(geyser_endpoint, geyser_api_token, geyser_auth_type, PumpAddresses.PROGRAM)
     callback = TestTokenCallback()
 
     if match_string:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated tests to support a new authentication type for Geyser API connections by reading an additional environment variable.
  - Adjusted test configuration to pass the authentication type when initializing the Geyser listener.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->