### PR TITLE
fix: correct the name of file

### DIFF
--- a/learning-examples/fetch_price.py
+++ b/learning-examples/fetch_price.py
@@ -14,7 +14,7 @@ LAMPORTS_PER_SOL: Final[int] = 1_000_000_000
 TOKEN_DECIMALS: Final[int] = 6
 CURVE_ADDRESS: Final[str] = "6GXfUqrmPM4VdN1NoDZsE155jzRegJngZRjMkGyby7do"
 
-# Here and later all the discriminators are precalculated. See learning-examples/discriminator.py
+# Here and later all the discriminators are precalculated. See learning-examples/calculate_discriminator.py
 EXPECTED_DISCRIMINATOR: Final[bytes] = struct.pack("<Q", 6966180631402821399)
 
 RPC_ENDPOINT = os.environ.get("SOLANA_NODE_RPC_ENDPOINT")

--- a/learning-examples/listen-new-tokens/listen_blocksubscribe.py
+++ b/learning-examples/listen-new-tokens/listen_blocksubscribe.py
@@ -55,7 +55,7 @@ def decode_create_instruction(ix_data, ix_def, accounts):
     return args
 
 
-# Here and later all the discriminators are precalculated. See learning-examples/discriminator.py
+# Here and later all the discriminators are precalculated. See learning-examples/calculate_discriminator.py
 async def listen_and_decode_create():
     idl = load_idl("idl/pump_fun_idl.json")
     create_discriminator = 8576854823835016728

--- a/learning-examples/manual_buy.py
+++ b/learning-examples/manual_buy.py
@@ -20,7 +20,7 @@ from solders.pubkey import Pubkey
 from solders.transaction import Transaction, VersionedTransaction
 from spl.token.instructions import get_associated_token_address
 
-# Here and later all the discriminators are precalculated. See learning-examples/discriminator.py
+# Here and later all the discriminators are precalculated. See learning-examples/calculate_discriminator.py
 EXPECTED_DISCRIMINATOR = struct.pack("<Q", 6966180631402821399)
 TOKEN_DECIMALS = 6
 

--- a/learning-examples/manual_sell.py
+++ b/learning-examples/manual_sell.py
@@ -15,7 +15,7 @@ from solders.pubkey import Pubkey
 from solders.transaction import Transaction
 from spl.token.instructions import get_associated_token_address
 
-# Here and later all the discriminators are precalculated. See learning-examples/discriminator.py
+# Here and later all the discriminators are precalculated. See learning-examples/calculate_discriminator.py
 EXPECTED_DISCRIMINATOR = struct.pack("<Q", 6966180631402821399)
 TOKEN_DECIMALS = 6
 


### PR DESCRIPTION
in comments change  from `learning-examples/discriminator.py` to `learning-examples/calculate_discriminator.py`