### PR TITLE
fix:use STRUCT_2 to parse creator

### DIFF
--- a/learning-examples/bonding-curve-progress/get_bonding_curve_status.py
+++ b/learning-examples/bonding-curve-progress/get_bonding_curve_status.py
@@ -71,7 +71,7 @@ class BondingCurveState:
             self.__dict__.update(parsed)
 
         else:
-            parsed = self._STRUCT_1.parse(data[8:])
+            parsed = self._STRUCT_2.parse(data[8:])
             self.__dict__.update(parsed) 
             # Convert raw bytes to Pubkey for creator field
             if hasattr(self, 'creator') and isinstance(self.creator, bytes):


### PR DESCRIPTION
* This is a subtle bug. but it should be fixed because when the bonding curve state data contains `creator`, it should use `_STRUCT_2` to parse. otherwise, using `_STRUCT_1` will always ignore the `creator`

* Dobule checked this issue exists only in `bonding-curve-progress/get_bonding_curve_status.py`