### PR TITLE
[chore]:.DS_store should be ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,5 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 trades/trades.log
+# Mac OS X
+.DS_Store


### PR DESCRIPTION
It would be nice if `.DS_store ` can be ignored by git.  because .DS_Store files are automatically created when you are viewing a folder by mac osx `Finder`.
